### PR TITLE
NUT: adjust driver.list path for nut-2.7

### DIFF
--- a/root/usr/share/nethesis/NethServer/Module/NutUps.php
+++ b/root/usr/share/nethesis/NethServer/Module/NutUps.php
@@ -31,7 +31,7 @@ class NutUps extends \Nethgui\Controller\AbstractController
     private function readModels() 
     {
         $this->models = array();
-        $handle = @fopen("/usr/share/driver.list", "r");
+        $handle = @fopen("/usr/share/nut/driver.list", "r");
         if ($handle) {
             while (($buffer = fgets($handle, 4096)) !== false) {
                 if ($buffer[0] == "#") {


### PR DESCRIPTION
Symptom: fill the Search driver for model, hit return: the wheel spins forever.
