### PR TITLE
collectd: enable nut plugin only if collectd-nut is installed. 

### DIFF
--- a/root/etc/e-smith/templates/etc/collectd.d/nut_nethserver.conf/20plugin
+++ b/root/etc/e-smith/templates/etc/collectd.d/nut_nethserver.conf/20plugin
@@ -1,7 +1,8 @@
 # If the UPS is locally attached collect data
 {
     $status = ${'nut-server'}{'status'} || 'disabled';
-    if ($status eq 'enabled') {
+    $collectd_nut = (-e "/usr/lib64/collectd/nut.so");
+    if ($status eq 'enabled' && $collectd_nut) {
         $OUT = <<EOF
 <Plugin "nut">
   UPS "ups\@localhost"


### PR DESCRIPTION
- Reworked to read status prop from nut-server key
- Reference NethServer/dev#5049