### PR TITLE
Support ups instance name and user

### DIFF
--- a/root/etc/e-smith/templates/etc/ups/upsmon.conf/20access
+++ b/root/etc/e-smith/templates/etc/ups/upsmon.conf/20access
@@ -1,6 +1,8 @@
 {
     my $ip = '';
     my $mode = '';
+    my $user = ${'nut-server'}{'User'} || 'upsmon';
+    my $ups = ${'nut-server'}{'Ups'} || 'UPS';
     my $pass = ${'nut-server'}{'Password'} || ' ';
     my $status = ${'nut-server'}{'status'} || 'disabled';
     if ($status eq 'enabled') {
@@ -11,5 +13,5 @@
         $mode = 'slave';
     }
 
-    $OUT.="MONITOR UPS\@$ip 1 upsmon $pass $mode";
+    $OUT.="MONITOR $ups\@$ip 1 $user $pass $mode";
 }


### PR DESCRIPTION
In some slave scenarios UPS, master UPS could not be a NethServer: in those cases, the user (`upsmon`) and the ups instance name (`UPS`) hardcoded into this template could no work.
We can change the "MONITOR" directive to use `nut-server` props and easily change the user and the ups instance name.

See PR NethServer/nethserver-nut#10